### PR TITLE
Support a basic snmp v1 for Walk() and Get()

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -55,6 +55,9 @@ func (s *SNMP) Walk(oids ...string) (*Rows, error) {
 		head:     lookup(oids...),
 		request:  s.do,
 	}
+	if s.Version == V1 {
+		rows.walkFn = walk1
+	}
 	for _, oid := range rows.head {
 		rows.last.bindings = append(rows.last.bindings, binding{Name: oid})
 	}


### PR DESCRIPTION
Inspired by Dave Cheneys blog about keeping the API stable, I've added an optional argument
where you can supply function-options.

It does take an extra invocation (first setup a new SNMP object, then using Walk or Get on it).

I'm still learning the ropes in Go, so I'm open to learn.
